### PR TITLE
upgrades for glitr_convert 0.2.4

### DIFF
--- a/glitr/gleam.toml
+++ b/glitr/gleam.toml
@@ -1,5 +1,5 @@
 name = "glitr"
-version = "0.1.14"
+version = "0.1.15"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
@@ -16,7 +16,7 @@ links = [{ title = "Website", href = "https://hexdocs.pm/glitr" }]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_json = ">= 1.0.1"
 gleam_http = ">= 3.6.0 and < 4.0.0"
-glitr_convert = ">= 0.1.12 and < 1.0.0"
+glitr_convert = ">= 0.2.4 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/glitr/manifest.toml
+++ b/glitr/manifest.toml
@@ -6,7 +6,7 @@ packages = [
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
   { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glitr_convert", version = "0.1.12", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "9722783812DA6C0DEDB159363D41C35F22E580CA34DEC8492EB75AF3953C4E3A" },
+  { name = "glitr_convert", version = "0.2.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "8C84731F004158C4C9A64E9C3E9BCCD4E9C9454B2CD692DA166CDEC0844C9A69" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
 ]
 
@@ -15,4 +15,4 @@ gleam_http = { version = ">= 3.6.0 and < 4.0.0" }
 gleam_json = { version = ">= 1.0.1" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-glitr_convert = { version = ">= 0.1.12 and < 1.0.0" }
+glitr_convert = { version = ">= 0.2.4 and < 1.0.0" }

--- a/glitr_convert_cake/gleam.toml
+++ b/glitr_convert_cake/gleam.toml
@@ -1,5 +1,5 @@
 name = "glitr_convert_cake"
-version = "0.1.14"
+version = "0.1.15"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
@@ -14,7 +14,7 @@ links = [{ title = "Website", href = "https://hexdocs.pm/glitr_convert_cake" }]
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-glitr_convert = ">= 0.1.13 and < 1.0.0"
+glitr_convert = ">= 0.2.4 and < 1.0.0"
 cake = ">= 1.0.0 and < 3.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"
 

--- a/glitr_convert_cake/manifest.toml
+++ b/glitr_convert_cake/manifest.toml
@@ -6,7 +6,7 @@ packages = [
   { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
   { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glitr_convert", version = "0.1.13", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "54BFF6B310BE584C4F7655F26A3B79DB2354668FB650B394FDC4F84F3E1B0472" },
+  { name = "glitr_convert", version = "0.2.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "8C84731F004158C4C9A64E9C3E9BCCD4E9C9454B2CD692DA166CDEC0844C9A69" },
 ]
 
 [requirements]
@@ -14,4 +14,4 @@ cake = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-glitr_convert = { version = ">= 0.1.13 and < 1.0.0" }
+glitr_convert = { version = ">= 0.2.4 and < 1.0.0" }

--- a/glitr_convert_cake/src/glitr/convert/cake.gleam
+++ b/glitr_convert_cake/src/glitr/convert/cake.gleam
@@ -10,8 +10,8 @@ import gleam/result
 import glitr/convert as c
 import glitr/convert/json as j
 
-/// Sets the columns and values of the Insert using the converter and the provided values.  
-/// If the converter isn't an Object converter, the value is left unchanged.  
+/// Sets the columns and values of the Insert using the converter and the provided values.
+/// If the converter isn't an Object converter, the value is left unchanged.
 /// This is because we don't have information about the fields/columns names otherwise.
 pub fn cake_insert(
   value: i.Insert(a),
@@ -33,8 +33,8 @@ pub fn cake_insert(
   }
 }
 
-/// Sets the column sets of the Update using the converter and the provided value.  
-/// If the converter isn't an Object converter, the value is left unchanged.  
+/// Sets the column sets of the Update using the converter and the provided value.
+/// If the converter isn't an Object converter, the value is left unchanged.
 /// This is because we don't have information about the fields/columns names otherwise.
 pub fn cake_update(
   value: u.Update(a),
@@ -52,7 +52,7 @@ pub fn cake_update(
   }
 }
 
-/// Sets the selected colums of the Select using the converter.  
+/// Sets the selected colums of the Select using the converter.
 /// If the converter isn't an Object converter, the value is left unchanged.
 /// This is because we don't have information about the fields/columns names otherwise.
 pub fn cake_select_fields(
@@ -187,5 +187,7 @@ fn type_as_str(of: c.GlitrType) -> String {
     c.Optional(_) -> "Optional"
     c.Result(_, _) -> "Result"
     c.String -> "String"
+    c.BitArray -> "BitArray"
+    c.Dynamic -> "Dynamic"
   }
 }

--- a/glitr_convert_sql/gleam.toml
+++ b/glitr_convert_sql/gleam.toml
@@ -1,5 +1,5 @@
 name = "glitr_convert_sql"
-version = "0.1.13"
+version = "0.1.14"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
@@ -14,7 +14,7 @@ links = [{ title = "Website", href = "https://hexdocs.pm/glitr_convert_sql" }]
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-glitr_convert = ">= 0.1.13 and < 1.0.0"
+glitr_convert = ">= 0.2.4 and < 1.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"
 
 [dev-dependencies]

--- a/glitr_convert_sql/manifest.toml
+++ b/glitr_convert_sql/manifest.toml
@@ -5,11 +5,11 @@ packages = [
   { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
   { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glitr_convert", version = "0.1.13", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "54BFF6B310BE584C4F7655F26A3B79DB2354668FB650B394FDC4F84F3E1B0472" },
+  { name = "glitr_convert", version = "0.2.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "8C84731F004158C4C9A64E9C3E9BCCD4E9C9454B2CD692DA166CDEC0844C9A69" },
 ]
 
 [requirements]
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-glitr_convert = { version = ">= 0.1.13 and < 1.0.0" }
+glitr_convert = { version = ">= 0.2.4 and < 1.0.0" }

--- a/glitr_convert_sql/test/insert_test.gleam
+++ b/glitr_convert_sql/test/insert_test.gleam
@@ -9,14 +9,14 @@ pub type User {
 pub fn insert_test() {
   let user_converter =
     convert.object({
-      use name <- convert.parameter
-      use age <- convert.parameter
-      use <- convert.constructor
-      User(name:, age:)
+      use name <- convert.field(
+        "name",
+        fn(u: User) { Ok(u.name) },
+        convert.string(),
+      )
+      use age <- convert.field("age", fn(u: User) { Ok(u.age) }, convert.int())
+      convert.success(User(name:, age:))
     })
-    |> convert.field("name", fn(u) { Ok(u.name) }, convert.string())
-    |> convert.field("age", fn(u) { Ok(u.age) }, convert.int())
-    |> convert.to_converter
 
   let my_user = User("Georges", 1)
 
@@ -27,14 +27,14 @@ pub fn insert_test() {
 pub fn insert_multiple_test() {
   let user_converter =
     convert.object({
-      use name <- convert.parameter
-      use age <- convert.parameter
-      use <- convert.constructor
-      User(name:, age:)
+      use name <- convert.field(
+        "name",
+        fn(u: User) { Ok(u.name) },
+        convert.string(),
+      )
+      use age <- convert.field("age", fn(u: User) { Ok(u.age) }, convert.int())
+      convert.success(User(name:, age:))
     })
-    |> convert.field("name", fn(u) { Ok(u.name) }, convert.string())
-    |> convert.field("age", fn(u) { Ok(u.age) }, convert.int())
-    |> convert.to_converter
 
   let georges = User("Georges", 1)
   let nemo = User("Nemo", 23)

--- a/glitr_convert_sql/test/select_test.gleam
+++ b/glitr_convert_sql/test/select_test.gleam
@@ -9,14 +9,14 @@ pub type User {
 pub fn select_test() {
   let user_converter =
     convert.object({
-      use name <- convert.parameter
-      use age <- convert.parameter
-      use <- convert.constructor
-      User(name:, age:)
+      use name <- convert.field(
+        "name",
+        fn(u: User) { Ok(u.name) },
+        convert.string(),
+      )
+      use age <- convert.field("age", fn(u: User) { Ok(u.age) }, convert.int())
+      convert.success(User(name:, age:))
     })
-    |> convert.field("name", fn(u) { Ok(u.name) }, convert.string())
-    |> convert.field("age", fn(u) { Ok(u.age) }, convert.int())
-    |> convert.to_converter
 
   sql.select("users", user_converter)
   |> should.equal("SELECT name, age FROM users;")

--- a/glitr_convert_sql/test/update_test.gleam
+++ b/glitr_convert_sql/test/update_test.gleam
@@ -9,14 +9,14 @@ pub type User {
 pub fn update_test() {
   let user_converter =
     convert.object({
-      use name <- convert.parameter
-      use age <- convert.parameter
-      use <- convert.constructor
-      User(name:, age:)
+      use name <- convert.field(
+        "name",
+        fn(u: User) { Ok(u.name) },
+        convert.string(),
+      )
+      use age <- convert.field("age", fn(u: User) { Ok(u.age) }, convert.int())
+      convert.success(User(name:, age:))
     })
-    |> convert.field("name", fn(u) { Ok(u.name) }, convert.string())
-    |> convert.field("age", fn(u) { Ok(u.age) }, convert.int())
-    |> convert.to_converter
 
   let my_user = User("Georges", 1)
 
@@ -27,14 +27,14 @@ pub fn update_test() {
 pub fn update_wrong_col_test() {
   let user_converter =
     convert.object({
-      use name <- convert.parameter
-      use age <- convert.parameter
-      use <- convert.constructor
-      User(name:, age:)
+      use name <- convert.field(
+        "name",
+        fn(u: User) { Ok(u.name) },
+        convert.string(),
+      )
+      use age <- convert.field("age", fn(u: User) { Ok(u.age) }, convert.int())
+      convert.success(User(name:, age:))
     })
-    |> convert.field("name", fn(u) { Ok(u.name) }, convert.string())
-    |> convert.field("age", fn(u) { Ok(u.age) }, convert.int())
-    |> convert.to_converter
 
   let georges = User("Georges", 1)
 

--- a/glitr_migrate/src/glitr/migrate/exec.gleam
+++ b/glitr_migrate/src/glitr/migrate/exec.gleam
@@ -78,10 +78,12 @@ fn exec_queries(
   case queries {
     [] -> Ok(Nil)
     [q, ..rest] -> {
-      io.println("Executing query : " <> q.sql)
-      io.print(" with values ")
-      io.debug(list.reverse(q.parameters))
-      io.println("")
+      // type pog.Query is opaque and no longer exposes its parts
+      
+      // io.println("Executing query : " <> q.sql)
+      // io.print(" with values ")
+      // io.debug(list.reverse(q.parameters))
+      // io.println("")
 
       let res = q |> pog.execute(conn)
       case res {

--- a/glitr_orm/gleam.toml
+++ b/glitr_orm/gleam.toml
@@ -1,5 +1,5 @@
 name = "glitr_orm"
-version = "1.0.0"
+version = "1.0.1"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
@@ -14,7 +14,7 @@ version = "1.0.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-glitr_convert = ">= 0.2.2 and < 1.0.0"
+glitr_convert = ">= 0.2.4 and < 1.0.0"
 glance = ">= 0.11.0 and < 1.0.0"
 glance_printer = ">= 1.2.1 and < 2.0.0"
 simplifile = ">= 2.2.0 and < 3.0.0"

--- a/glitr_orm/manifest.toml
+++ b/glitr_orm/manifest.toml
@@ -10,7 +10,7 @@ packages = [
   { name = "gleam_stdlib", version = "0.41.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1B2F80CB1B66B027E3198A2FF71EF3F2F31DF89ED97AD606F25FD387A4C3C1EF" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
-  { name = "glitr_convert", version = "0.2.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "9FC5613751AD86F592A7274B281AEF28396096C56B6DED8834DA8B3E9E244FAC" },
+  { name = "glitr_convert", version = "0.2.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "glitr_convert", source = "hex", outer_checksum = "8C84731F004158C4C9A64E9C3E9BCCD4E9C9454B2CD692DA166CDEC0844C9A69" },
   { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
@@ -20,6 +20,6 @@ glance = { version = ">= 0.11.0 and < 1.0.0" }
 glance_printer = { version = ">= 1.2.1 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-glitr_convert = { version = ">= 0.2.2 and < 1.0.0" }
+glitr_convert = { version = ">= 0.2.4 and < 1.0.0" }
 shellout = { version = ">= 1.6.0 and < 2.0.0" }
 simplifile = { version = ">= 2.2.0 and < 3.0.0" }

--- a/glitr_orm/src/glitr/orm/convert.gleam
+++ b/glitr_orm/src/glitr/orm/convert.gleam
@@ -11,7 +11,11 @@ const time_sep = ":"
 
 pub fn date() -> convert.Converter(orm.Date) {
   convert.string()
-  |> convert.map(date_to_str, str_to_date)
+  |> convert.map(
+    date_to_str,
+    fn(str) { Ok(str_to_date(str)) },
+    orm.Date(year: -1, month: -1, day: -1),
+  )
 }
 
 fn date_to_str(v: orm.Date) -> String {
@@ -34,7 +38,11 @@ fn str_to_date(v: String) -> orm.Date {
 
 pub fn time() -> convert.Converter(orm.Time) {
   convert.string()
-  |> convert.map(time_to_str, str_to_time)
+  |> convert.map(
+    time_to_str,
+    fn(str) { Ok(str_to_time(str)) },
+    orm.Time(-1, -1, -1),
+  )
 }
 
 fn time_to_str(v: orm.Time) -> String {
@@ -68,6 +76,8 @@ pub fn timestamp() -> convert.Converter(orm.Timestamp) {
         [d] -> orm.Timestamp(str_to_date(d), orm.Time(-1, -1, -1))
         [] -> orm.Timestamp(orm.Date(-1, -1, -1), orm.Time(-1, -1, -1))
       }
+      |> Ok
     },
+    orm.Timestamp(date: orm.Date(-1, -1, -1), time: orm.Time(-1, -1, -1)),
   )
 }


### PR DESCRIPTION
Updates to `glitr_convert` impacted `glitr_convert_cake`. Gave everything a tune-up and a patch-version bump while I was at it.

All builds and tests passed, sans glitr_convert (I'm assuming your tests passed earlier today, and gleam_json@2.0.0 is throwing a fit over Erlang 27.1.2 for me)